### PR TITLE
Revert "Defined baseurl as absolute"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: IdentityServer
 email: identity@thinktecture.com
 description: IdentityServer
-baseurl: "https://thintecture.github.io/Thinktecture.IdentityServer.v3.Documentation" # the subpath of your site, e.g. /blog/
+baseurl: "/Thinktecture.IdentityServer.v3.Documentation" # the subpath of your site, e.g. /blog/
 url: "https://thinktecture.github.io" # the base hostname & protocol for your site
 twitter_username: identityserver
 github_username:  thinktecture


### PR DESCRIPTION
Reverts thinktecture/Thinktecture.IdentityServer.v3.Documentation#5