### PR TITLE
IdentityProviders.md: Changed the caption for Twitter auth to '"Twitter"

### DIFF
--- a/docs/configuration/identityProviders.md
+++ b/docs/configuration/identityProviders.md
@@ -36,7 +36,7 @@ public static void ConfigureIdentityProviders(IAppBuilder app, string signInAsTy
     var twitter = new TwitterAuthenticationOptions
     {
         AuthenticationType = "Twitter",
-        Caption = "Facebook",
+        Caption = "Twitter",
         SignInAsAuthenticationType = signInAsType,
         ConsumerKey = "...",
         ConsumerSecret = "..."


### PR DESCRIPTION
It was 'Facebook'